### PR TITLE
新增OCR返回多结果时，通过设定坐标范围筛选结果方法

### DIFF
--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -123,6 +123,25 @@ class OCRUtils:
     def all_result(cls):
         return cls.result
 
+    @classmethod
+    def ocr_find_by_range(cls, text, x1=0, x2=1920, y1=0, y2=1080):
+        """
+        OCR在界面中识别到多个关键词时，通过区域筛选出对应关键词并返回坐标
+        :param text: 页面查找关键词
+        :param x1: x坐标开始范围
+        :param x2: x坐标结束范围
+        :param y1: y坐标开始范围
+        :param y2: y坐标结束范围
+        :return: 坐标 x, y
+        """
+        ocr_return = cls.ocr(text)
+        if isinstance(ocr_return, tuple):
+            return ocr_return[0], ocr_return[1]
+        elif isinstance(ocr_return, dict):
+            for key, value in ocr_return.items():
+                if x1 <= value[0] <= x2 and y1 <= value[1] <= y2:
+                    return value[0], value[1]
+
 
 if __name__ == '__main__':
     OCRUtils.ocrx().click()

--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -124,7 +124,7 @@ class OCRUtils:
         return cls.result
 
     @classmethod
-    def ocr_find_by_range(cls, text, x1=0, x2=1920, y1=0, y2=1080):
+    def ocr_find_by_range(cls, text, x1=None, x2=None, y1=None, y2=None):
         """
         OCR在界面中识别到多个关键词时，通过区域筛选出对应关键词并返回坐标
         :param text: 页面查找关键词
@@ -132,15 +132,34 @@ class OCRUtils:
         :param x2: x坐标结束范围
         :param y1: y坐标开始范围
         :param y2: y坐标结束范围
-        :return: 坐标 x, y
+        :return: 坐标元组 (x, y)
+
+        注意：需要特定区域内只有一组OCR关键词，若任有多组请增加精度，否则默认返回第一组符合条件的关键词坐标
+
+        以默认分辨率 1920*1080 为例，多种示例情况如下：
+        示例1（识别左半屏幕关键字）：ocr_find_by_range(x1=960)
+        示例2（识别下半屏幕关键字）：ocr_find_by_range(y1=540)
+        示例3（识别左半屏幕-上半屏关键字）：ocr_find_by_range(x1=960, y1=540)
+        示例4（识别特定区域 ：100*900-200*950 内关键字）：ocr_find_by_range(x1=100, x2=200, y1=900, y2=950)
         """
+        defaults = {
+            'x1': 0,
+            'x2': 1920,
+            'y1': 0,
+            'y2': 1080
+        }
+
+        x1 = x1 if x1 is not None else defaults['x1']
+        x2 = x2 if x2 is not None else defaults['x2']
+        y1 = y1 if y1 is not None else defaults['y1']
+        y2 = y2 if y2 is not None else defaults['y2']
+
         ocr_return = cls.ocr(text)
-        if isinstance(ocr_return, tuple):
-            return ocr_return[0], ocr_return[1]
-        elif isinstance(ocr_return, dict):
+        if isinstance(ocr_return, dict):
             for key, value in ocr_return.items():
                 if x1 <= value[0] <= x2 and y1 <= value[1] <= y2:
-                    return value[0], value[1]
+                    return value
+        return ocr_return
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
场景：使用OCR关键词操作页面时，关键词不唯一，使用OCR识别后会返回多个坐标。
使用：如果该关键词在UI中出现的位置相对固定，那则可以通过坐标范围筛选出我们想要的那个位置，而且范围不用那么精准，所以 `UI` 变动不是太大，依然可以兼容，同时比图像识别更加方便。

实例：例如下图我需要点击左侧列表的关键词 `/dev/nvme0n1` ，传入一个 `X` 坐标范围即可，若 `X` 坐标相近，还可以加入 `Y` 坐标进行辅助，提升精准度。
![截图_选择区域_20240529163952](https://github.com/linuxdeepin/youqu/assets/90230279/dbf4aa75-3917-49a1-bd4a-3024a4c98449)
