### PR TITLE
增加部署环境时，ctrl+c 完全终止部署流程方法

### DIFF
--- a/src/utils/_env_base.sh
+++ b/src/utils/_env_base.sh
@@ -2,6 +2,13 @@
 # SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 # SPDX-License-Identifier: GPL-2.0-only
 
+ctrl_c_handler(){
+    echo "正在退出……"
+    exit 1
+}
+
+trap ctrl_c_handler INT
+
 check_status(){
     if [ $? = 0 ]; then
         echo -e "$1\t安装成功 √"


### PR DESCRIPTION
解决环境部署时，Ctrl C无法完全退出问题
![image](https://github.com/user-attachments/assets/96d8f3c4-1dfa-4329-ad4c-81d28ee6f853)
