### PR TITLE
环境部署脚本应该在发生错误时立即退出，否则会造成后续继续执行

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 # SPDX-License-Identifier: GPL-2.0-only
 export PIPENV_VERBOSITY=-1

--- a/src/rtk/remote_runner.py
+++ b/src/rtk/remote_runner.py
@@ -214,7 +214,7 @@ class RemoteRunner:
         )
         system(
             f"{self.ssh % password} {user}@{_ip} "
-            f'"cd ~/{self.server_project_path}/ && bash env.sh"'
+            f'"cd ~/{self.server_project_path}/ && bash env.sh -p {password}"'
         )
         logger.info(f"环境安装完成 - < {user}@{_ip} >")
 


### PR DESCRIPTION
在首次部署环境 或 远程执行中部署环境，环境部署异常应该立即退出，而不是继续执行
![image](https://github.com/user-attachments/assets/1b67fdf5-3282-4056-a404-0ebce19a96c0)
