### PR TITLE
临时处理input_message方法，在wayland输入中文末尾多出空格的问题

### DIFF
--- a/src/mouse_key.py
+++ b/src/mouse_key.py
@@ -278,6 +278,8 @@ class MouseKey:
                 if wayland_shift:
                     _hk.insert(1, "shift")
                 cls.hot_key(*_hk)
+                # 目前的方案中，粘贴内容后会在末尾会多出一个空格，临时处理：去掉末尾空格
+                cls.press_key("backspace")
             else:
                 for key in message:
                     if _ydotool:


### PR DESCRIPTION
input_message方法在wayland输入中文末尾多出空格，在【粘贴】操作后增加一个【退格】动作，临时规避这个问题