### PR TITLE
1、修复assert_ocr_not_exist断言Bug2、扩展assert_ocr_exist 与 assert_ocr_not_exist断言3、优化OCR识别范围筛选方法

### DIFF
--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -41,17 +41,17 @@ class OCRUtils:
 
     @classmethod
     def ocr_remote(
-            cls,
-            target_strings: tuple = None,
-            picture_abspath: str = None,
-            similarity: [int, float] = 0.6,
-            return_default: bool = False,
-            return_first: bool = False,
-            lang: str = "ch",
-            network_retry: int = None,
-            pause: [int, float] = None,
-            timeout: [int, float] = None,
-            max_match_number: int = None,
+        cls,
+        target_strings: tuple = None,
+        picture_abspath: str = None,
+        similarity: [int, float] = 0.6,
+        return_default: bool = False,
+        return_first: bool = False,
+        lang: str = "ch",
+        network_retry: int = None,
+        pause: [int, float] = None,
+        timeout: [int, float] = None,
+        max_match_number: int = None,
     ):
         servers = cls.ocr_servers
         while servers:
@@ -96,6 +96,7 @@ class OCRUtils:
     @classmethod
     def click(cls):
         from src.mouse_key import MouseKey
+
         cls._check_xy()
         MouseKey.click(cls.x, cls.y)
         return cls
@@ -103,6 +104,7 @@ class OCRUtils:
     @classmethod
     def right_click(cls):
         from src.mouse_key import MouseKey
+
         cls._check_xy()
         MouseKey.right_click(cls.x, cls.y)
         return cls
@@ -110,6 +112,7 @@ class OCRUtils:
     @classmethod
     def double_click(cls):
         from src.mouse_key import MouseKey
+
         cls._check_xy()
         MouseKey.double_click(cls.x, cls.y)
         return cls
@@ -126,41 +129,51 @@ class OCRUtils:
     @classmethod
     def ocr_find_by_range(cls, text, x1=None, x2=None, y1=None, y2=None):
         """
-        OCR在界面中识别到多个关键词时，通过区域筛选出对应关键词并返回坐标
-        :param text: 页面查找关键词
-        :param x1: x坐标开始范围
-        :param x2: x坐标结束范围
-        :param y1: y坐标开始范围
-        :param y2: y坐标结束范围
+        OCR在当前界面中识别到多个关键词时，通过区域筛选出对应关键词并返回坐标
+        :param text: 页面范围内查找关键词，可自由使用以下参数划定查找区域
+        :param x1: x坐标开始范围，有效区域为大于 x1 区域
+        :param x2: x坐标结束范围，有效区域为小于 x1 区域
+        :param y1: y坐标开始范围，有效区域为大于 y1 区域
+        :param y2: y坐标结束范围，有效区域为小于 y2 区域
         :return: 坐标元组 (x, y)
 
-        注意：需要特定区域内只有一组OCR关键词，若任有多组请增加精度，否则默认返回第一组符合条件的关键词坐标
+        注意：该方法设计是为了筛选出唯一坐标，所以需要特定区域内只有一组OCR关键词，若任有多组数据会直接报错，请增加精度
 
         以默认分辨率 1920*1080 为例，多种示例情况如下：
-        示例1（识别左半屏幕关键字）：ocr_find_by_range(x1=960)
+        示例1（识别左半屏幕关键字）：ocr_find_by_range(x2=960)
         示例2（识别下半屏幕关键字）：ocr_find_by_range(y1=540)
-        示例3（识别左半屏幕-上半屏关键字）：ocr_find_by_range(x1=960, y1=540)
-        示例4（识别特定区域 ：100*900-200*950 内关键字）：ocr_find_by_range(x1=100, x2=200, y1=900, y2=950)
+        示例3（识别右下半屏幕关键字）：ocr_find_by_range(x1=960, y1=540)
+        示例4（识别特定区域 ：100*900-200*950 内关键字）：ocr_find_by_range(x1=100, y1=900, x2=200, y2=950)
         """
-        defaults = {
-            'x1': 0,
-            'x2': 1920,
-            'y1': 0,
-            'y2': 1080
-        }
+        defaults = {"x1": 0, "x2": 1920, "y1": 0, "y2": 1080}
 
-        x1 = x1 if x1 is not None else defaults['x1']
-        x2 = x2 if x2 is not None else defaults['x2']
-        y1 = y1 if y1 is not None else defaults['y1']
-        y2 = y2 if y2 is not None else defaults['y2']
+        x1 = x1 if x1 is not None else defaults["x1"]
+        x2 = x2 if x2 is not None else defaults["x2"]
+        y1 = y1 if y1 is not None else defaults["y1"]
+        y2 = y2 if y2 is not None else defaults["y2"]
 
+        if x1 > x2 or y1 > y2:
+            raise ValueError("x1 > x2 or y1 > y2")
+
+        results = []
         ocr_return = cls.ocr(text)
         if isinstance(ocr_return, dict):
-            for key, value in ocr_return.items():
+            for _, value in ocr_return.items():
                 if x1 <= value[0] <= x2 and y1 <= value[1] <= y2:
-                    return value
-        return ocr_return
-
-
-if __name__ == '__main__':
-    OCRUtils.ocrx().click()
+                    results.append(value)
+            if len(results) == 0:
+                raise ValueError(
+                    f"范围内[{x1, y1} - {x2, y2}]未识别到关键词[{text}]，请增加识别精度，识别结果为：{results}"
+                )
+            elif len(results) == 1:
+                return results[0]
+            else:
+                raise ValueError(
+                    f"范围内[{x1, y1} - {x2, y2}]识别到多组关键词[{text}]，请增加识别精度，识别结果为：{results}"
+                )
+        if x1 <= ocr_return[0] <= x2 and y1 <= ocr_return[1] <= y2:
+            return ocr_return
+        else:
+            raise ValueError(
+                f"范围内[{x1, y1} - {x2, y2}]识别不到关键词，请增加识别精度，识别结果为：{ocr_return}"
+            )


### PR DESCRIPTION
1、修复assert_ocr_not_exist断言Bug
修复在传入多个参数时，断言无效的Bug

2、扩展assert_ocr_exist 与 assert_ocr_not_exist断言
增加bbox参数，新增区域断言支持，主要用于解决当整个屏幕内容较多，干扰较大时OCR精准度过低问题

3、优化OCR识别范围筛选方法
修改了使用方法，历史调用中在区域内查找到了多个关键字会返回第一组坐标，但该结果违背了使用此方法的初衷（当结果出现多个关键词坐标时，进行范围筛选，得出我们需要的唯一坐标），这里增加了过程校验，确保最终只能返回唯一坐标