### PR TITLE
修复远程执行客户端执行用例抛出文件无法打开异常

### DIFF
--- a/src/remotectl/_base.py
+++ b/src/remotectl/_base.py
@@ -169,6 +169,8 @@ def remote_client(ip, port):
         return c
     except Exception as e:
         raise e
+    finally:
+        c.close()
 
 
 def remote_server(obj, port):


### PR DESCRIPTION
修复远程执行客户端执行用例抛出文件无法打开异常